### PR TITLE
Typo in a few containers

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -20,12 +20,12 @@
 				{
 					"label": "CONTEXT_PATH",
 					"name": "CONTEXT_PATH",
-					"set": "airsonic"
+					"default": "airsonic"
 				},
 				{
 					"label": "JAVA_OPTS",
 					"name": "JAVA_OPTS",
-					"set": "-Xms256m -Xmx512m"
+					"default": "-Xms256m -Xmx512m"
 				}
 			],
 			"image": "linuxserver/airsonic:latest",
@@ -556,27 +556,27 @@
 				{
 					"label": "EMAIL",
 					"name": "EMAIL",
-					"set": "-Xms256m -Xmx512m"
+					"default": "-Xms256m -Xmx512m"
 				},
 				{
 					"label": "URL",
 					"name": "URL",
-					"set": "-Xms256m -Xmx512m"
+					"default": "-Xms256m -Xmx512m"
 				},
 				{
 					"label": "SUBDOMAINS",
 					"name": "SUBDOMAINS",
-					"set": "www,"
+					"default": "www,"
 				},
 				{
 					"label": "ONLY_SUBDOMAINS",
 					"name": "ONLY_SUBDOMAINS",
-					"set": "false"
+					"default": "false"
 				},
 				{
 					"label": "DHLEVEL",
 					"name": "DHLEVEL",
-					"set": "2048"
+					"default": "2048"
 				},
 				{
 					"default": "1000",
@@ -591,12 +591,12 @@
 				{
 					"label": "VALIDATION",
 					"name": "VALIDATION",
-					"set": "http"
+					"default": "http"
 				},
 				{
 					"label": "DNSPLUGIN",
 					"name": "DNSPLUGIN",
-					"set": "http"
+					"default": "http"
 				}
 			],
 			"image": "linuxserver/letsencrypt:latest",
@@ -701,7 +701,7 @@
 				{
 					"label": "MYSQL_ROOT_PASSWORD",
 					"name": "MYSQL_ROOT_PASSWORD",
-					"set": ""
+					"default": ""
 				}
 			],
 			"image": "linuxserver/mariadb:latest",
@@ -729,17 +729,17 @@
 			"description": "JDownloader docker image",
 			"env": [
 				{
-					"set": "",
+					"default": "",
 					"label": "MYJD_DEVICE",
 					"name": "MYJD_DEVICE"
 				},
 				{
-					"set": "",
+					"default": "",
 					"label": "MYJD_USER",
 					"name": "MYJD_USER"
 				},
 				{
-					"set": "",
+					"default": "",
 					"label": "MYJD_PASSWORD",
 					"name": "MYJD_PASSWORD"
 				}
@@ -964,7 +964,7 @@
 				{
 					"label": "BRAINZCODE",
 					"name": "BRAINZCODE",
-					"set": ""
+					"default": ""
 				},
 				{
 					"default": "1000",
@@ -1311,7 +1311,7 @@
 				{
 					"label": "INTERFACE",
 					"name": "INTERFACE",
-					"set": "eth0"
+					"default": "eth0"
 				},
 				{
 					"default": "1000",
@@ -1543,27 +1543,27 @@
 				{
 					"label": "CHEVERETO_DB_HOST",
 					"name": "CHEVERETO_DB_HOST",
-					"set": ""
+					"default": ""
 				},
 				{
 					"label": "CHEVERETO_DB_USERNAME",
 					"name": "CHEVERETO_DB_USERNAME",
-					"set": ""
+					"default": ""
 				},
 				{
 					"label": "CHEVERETO_DB_PASSWORD",
 					"name": "CHEVERETO_DB_PASSWORD",
-					"set": ""
+					"default": ""
 				},
 				{
 					"label": "CHEVERETO_DB_NAME",
 					"name": "CHEVERETO_DB_NAME",
-					"set": ""
+					"default": ""
 				},
 				{
 					"label": "CHEVERETO_DB_PREFIX",
 					"name": "CHEVERETO_DB_PREFIX",
-					"set": ""
+					"default": ""
 				}
 			],
 			"image": "nmtan/chevereto:latest",
@@ -1991,7 +1991,7 @@
 				{
 					"label": "UMASK",
 					"name": "UMASK",
-					"set": "000"
+					"default": "000"
 				}
 			],
 			"image": "linuxserver/deluge:latest",
@@ -2059,12 +2059,12 @@
 				{
 					"label": "SUBDOMAINS",
 					"name": "SUBDOMAINS",
-					"set": ""
+					"default": ""
 				},
 				{
 					"label": "TOKEN",
 					"name": "TOKEN",
-					"set": ""
+					"default": ""
 				},
 				{
 					"default": "1000",
@@ -2510,7 +2510,7 @@
 				{
 					"label": "VERSION",
 					"name": "VERSION",
-					"set": "latest"
+					"default": "latest"
 				}
 			],
 			"image": "linuxserver/plex:latest",
@@ -2558,7 +2558,7 @@
 				{
 					"label": "URL_BASE",
 					"name": "URL_BASE",
-					"set": ""
+					"default": ""
 				}
 			],
 			"image": "linuxserver/plexrequests:latest",
@@ -3509,7 +3509,7 @@
 				{
 					"label": "MAXMEM",
 					"name": "MAXMEM",
-					"set": "512"
+					"default": "512"
 				},
 				{
 					"default": "1000",
@@ -3757,7 +3757,7 @@
 				{
 					"label": "CONTEXT_PATH",
 					"name": "CONTEXT_PATH",
-					"set": "UniFi Video"
+					"default": "UniFi Video"
 				}
 			],
 			"image": "pducharme/unifi-video-controller:latest",


### PR DESCRIPTION
I was trying to get OpenVPN-AS to work and ran into some trouble. I had previously manually set the INTERFACE variable to "eth0", then I noticed that you were using "set" instead of "default. So I just went through and changed them all.
https://docs.portainer.io/v/ce-2.6/advanced/app-templates/format#env

Unfortunately, I still haven't been able to stand up a working OpenVPN-AS container yet. It seems to be complaing about a formatting issue. I have tried adding in the TZ environment varriable and the capability NET_ADMIN as per the sample in their documentation, with no success.

Thanks again for this series.