### PR TITLE
speedtest-tracker: accept Ookla license upon container start

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -4091,7 +4091,7 @@
 					"default": "100",
 					"label": "PGID",
 					"name": "PGID"
-				}
+				},
 				{
 					"label": "OOKLA_EULA_GDPR",
 					"name": "OOKLA_EULA_GDPR",


### PR DESCRIPTION
Deployment of the speedtest-tracker container will fail without this environment variable set to `true`.