### PR TITLE
Add arm compatible mariadb image in proxy-manager

### DIFF
--- a/pi-hosted_template/stack/nginx-proxy-manager.yml
+++ b/pi-hosted_template/stack/nginx-proxy-manager.yml
@@ -21,7 +21,7 @@ services:
       - 81:81
     restart: unless-stopped
   db:
-    image: yobasystems/alpine-mariadb:latest
+    image: arm64v8/mariadb:10.5
     restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}


### PR DESCRIPTION
# Summary
The current image of MariaDB listed is not compatible with raspberry pi. I have added arm compatible working image
<!-- A short summary describing what was done... -->

# Why This Is Needed
To make sure nginx-proxy-manager works on docker
<!-- Explain why this change is needed. Can be omitted if covered in the summary. -->

# What Changed
<!-- A detailed list of all the changes made, broken down by category. -->
nginx-proxy-manager docker-compose file

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
- [ ] Have you updated documentation, as applicable?