### PR TITLE
Add additional Parm needed for some OpenVPN providers in transmission-openvpn

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -3545,6 +3545,12 @@
 					"label": "OPENVPN_PROVIDER",
 					"name": "OPENVPN_PROVIDER"
 				},
+                                {
+                                        "default": "",
+                                        "description": "Optional. Mostly used to narrow down what location to use by the provider",
+                                        "label": "OPENVPN_CONFIG",
+                                        "name": "OPENVPN_CONFIG"
+                                },
 				{
 					"default": "",
 					"label": "OPENVPN_USERNAME",


### PR DESCRIPTION
<!-- The title of the pull request should be a short description of what was done.  -->

<!-- You can remove any parts of this template not applicable to your Pull Request.  -->

# Summary
I was helping a user who couldn't get connected to his provider.  In the end I added in the extra env variable and it started working right away.  It looks like this is needed for most providers so it is a useful addon.
<!-- A short summary describing what was done... -->

# Why This Is Needed

<!-- Explain why this change is needed. Can be omitted if covered in the summary. -->
Many providers require the additional setting.
## Added

<!-- What was added? -->
Added new parm to support VPN providers.
# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
- [x] Have you updated documentation, as applicable?