### PR TITLE
Change Protonmail-Bridge version to run on Raspberry Pi

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -2889,7 +2889,7 @@
 				"Other"
 			],
 			"description": "This is an unofficial Docker container of the ProtonMail Bridge. Some of the scripts are based on Hendrik Meyer's work.",
-			"image": "shenxn/protonmail-bridge:latest",
+			"image": "shenxn/protonmail-bridge:1.4.5-build",
 			"logo": "https://raw.githubusercontent.com/novaspirit/pi-hosted/master/pi-hosted_template/images/protonmail-bridge.png",
 			"name": "protonmail-bridge",
 			"note": "Please refer to the documentation \u003ca href='https://hub.docker.com/r/shenxn/protonmail-bridge'/\u003ehere\u003c/a\u003e to set this up.",


### PR DESCRIPTION
# Summary

As per docker maintainer, the latest version has a problem and it doesn't run on Raspberry Pi. The latest working version is 1.4.5-build.

See: [https://github.com/shenxn/protonmail-bridge-docker]()

# Why This Is Needed

Latest version doesn't work on Raspberry Pi

# What Changed

Portainer Template to change docker tag

## Fixed

Protonmail-Bridge tag on Portainer Template to the latest working version for Raspberry Pi

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated documentation, as applicable?