### PR TITLE
Assign a Port for Freshrss so it doesn't just select a random port during startup.

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -2433,7 +2433,7 @@
 			"name": "freshrss",
 			"platform": "linux",
 			"ports": [
-				"80/tcp"
+				"8132:80/tcp"
 			],
 			"restart_policy": "unless-stopped",
 			"title": "FreshRSS",


### PR DESCRIPTION
# Summary
Assigned it port 8132 as it needs something defined or it will get a random port.  Nothing in the project notes indict a prefered port so I selected one at random.

# Why This Is Needed
If you don't assign one it will end up with a port at random.  Nothing on the project pages or the docker hub pages includes a port other than port 80 but we need to set it to something or it would change ports on each boot.

# What Changed
Assigned it a port that isn't currently in use.
# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated documentation, as applicable?