### PR TITLE
Use latest docker image for whoogle

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -4661,7 +4661,7 @@
 				"Tools"
 			],
 			"description": "Self-hosted, ad-free, privacy-respecting Google metasearch engine.",
-			"image": "benbusby/whoogle-search:buildx-experimental",
+			"image": "benbusby/whoogle-search:latest",
 			"logo": "https://raw.githubusercontent.com/novaspirit/pi-hosted/master/images/whoogle.png",
 			"name": "whoogle",
 			"platform": "linux",


### PR DESCRIPTION
The latest docker image which at the time of making this pr is v6.0 is not being used, as the `latest` tag isn't being used. I have just changed that :)
