### PR TITLE
Changed Samba Configuration

### DIFF
--- a/template/portainer-v2-arm32.json
+++ b/template/portainer-v2-arm32.json
@@ -3956,7 +3956,7 @@
 				"139:139/tcp",
 				"445:445/tcp"
 			],
-			"command": "-s 'portainer;/share;yes;no;yes;guest' -g 'map to guest = never' -g 'restrict anonymous = 2'",
+			"command": "",
 			"restart_policy": "unless-stopped",
 			"title": "Samba",
 			"type": 1,
@@ -3968,14 +3968,34 @@
 					"name": "PUID"
 				},
 				{
+					"default": "1000",
+					"label": "PGID",
+					"name": "PGID"
+				},
+				{
+					"default": "1000",
+					"label": "USERID",
+					"name": "USERID"
+				},
+				{
+					"default": "1000",
+					"label": "GROUPID",
+					"name": "GROUPID"
+				},
+				{
 					"default": "guest;guest",
 					"label": "USER",
 					"name": "USER"
 				},
 				{
-					"default": "1000",
-					"label": "PGID",
-					"name": "PGID"
+					"default": "true",
+					"label": "PERMISSIONS",
+					"name": "PERMISSIONS"
+				},
+				{
+					"default": "portainer;/share;yes;no;yes;guest",
+					"label": "SHARE",
+					"name": "SHARE"
 				}
 			],
 			"volumes": [


### PR DESCRIPTION
# Summary
- New directories and files have owner Pi (No need for chmod 777)
- First user name: USER
- Second and third user name: USER2, USER3
- First share name: SHARE
- Second and third share name: SHARE2, SHARE3
See: https://github.com/dperson/samba
NOTE3: optionally supports additional variables starting with the same name, IE SHARE also will work for SHARE2, SHARE3... SHAREx, etc.
Not sure if PERMISSIONS are needed

# Why This Is Needed
No need for chmod 777

# Checklist
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable?