### PR TITLE
Change prometheus job name to Pi-Hosted

### DIFF
--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -1,5 +1,5 @@
 scrape_configs:
-  - job_name: 'prometheus'
+  - job_name: 'Pi-Hosted'
     scrape_interval: 30s
     static_configs:
       - targets: ['localhost:9090', 'cadvisor:8080', 'node-exporter:9100']


### PR DESCRIPTION
# Summary

Change prometheus job name to `Pi-Hosted`. This makes it easier if running grafana with other dashboards and prometheus.

# Why This Is Needed

When there is a duplicated data (gather from more than one place) the job name is the one that appears on the screen for differentiate. Having it a more meaningful name helps. 

# What Changed

Just prometheus config file

## Changed

- config/prometheus.yml

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable? [not applicable]