### PR TITLE
Add pi user to Homer Template

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -1776,6 +1776,18 @@
 			"restart_policy": "unless-stopped",
 			"title": "Homer",
 			"type": 1,
+			"env": [
+				{
+					"default": "1000",
+					"label": "GID",
+					"name": "GID"
+				},
+				{
+					"default": "1000",
+					"label": "UID",
+					"name": "UID"
+				}
+			],
 			"volumes": [
 				{
 					"bind": "/portainer/Files/AppData/Config/Homer/assets",

--- a/template/portainer-v2-arm32.json
+++ b/template/portainer-v2-arm32.json
@@ -1776,6 +1776,18 @@
 			"restart_policy": "unless-stopped",
 			"title": "Homer",
 			"type": 1,
+			"env": [
+				{
+					"default": "1000",
+					"label": "GID",
+					"name": "GID"
+				},
+				{
+					"default": "1000",
+					"label": "UID",
+					"name": "UID"
+				}
+			],
 			"volumes": [
 				{
 					"bind": "/portainer/Files/AppData/Config/Homer/assets",

--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -1876,6 +1876,18 @@
 			"restart_policy": "unless-stopped",
 			"title": "Homer",
 			"type": 1,
+			"env": [
+				{
+					"default": "1000",
+					"label": "GID",
+					"name": "GID"
+				},
+				{
+					"default": "1000",
+					"label": "UID",
+					"name": "UID"
+				}
+			],
 			"volumes": [
 				{
 					"bind": "/portainer/Files/AppData/Config/Homer/assets",


### PR DESCRIPTION
# Summary

Add GID and UID to Homer template so pi user can modify config files.

# Why This Is Needed

This makes the life much easier.

## Changed

- pi-hosted_template/template/portainer-v2.json
- template/portainer-v2-arm32.json
- template/portainer-v2-arm64.json

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [] Have you updated documentation, as applicable? [Not applicable]