### PR TITLE
Add pi user to MStream Template

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -2667,6 +2667,18 @@
 			"restart_policy": "unless-stopped",
 			"title": "Mstream",
 			"type": 1,
+			"env": [
+				{
+					"default": "1000",
+					"label": "PUID",
+					"name": "PUID"
+				},
+				{
+					"default": "1000",
+					"label": "PGID",
+					"name": "PGID"
+				}
+			],
 			"volumes": [
 				{
 					"bind": "/portainer/Files/AppData/Config/Mstream",

--- a/template/portainer-v2-arm32.json
+++ b/template/portainer-v2-arm32.json
@@ -2667,6 +2667,18 @@
 			"restart_policy": "unless-stopped",
 			"title": "Mstream",
 			"type": 1,
+			"env": [
+				{
+					"default": "1000",
+					"label": "PUID",
+					"name": "PUID"
+				},
+				{
+					"default": "1000",
+					"label": "PGID",
+					"name": "PGID"
+				}
+			],
 			"volumes": [
 				{
 					"bind": "/portainer/Files/AppData/Config/Mstream",

--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -2767,6 +2767,18 @@
 			"restart_policy": "unless-stopped",
 			"title": "Mstream",
 			"type": 1,
+			"env": [
+				{
+					"default": "1000",
+					"label": "PUID",
+					"name": "PUID"
+				},
+				{
+					"default": "1000",
+					"label": "PGID",
+					"name": "PGID"
+				}
+			],
 			"volumes": [
 				{
 					"bind": "/portainer/Files/AppData/Config/Mstream",


### PR DESCRIPTION
# Summary

Add PGID and PUID to MStream template so pi user can modify music files.

## Changed

- pi-hosted_template/template/portainer-v2.json
- template/portainer-v2-arm32.json
- template/portainer-v2-arm64.json

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [] Have you updated documentation, as applicable? [Not applicable]