### PR TITLE
Update Minecraft Server Template to use latest image

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -2574,7 +2574,7 @@
                 "Games"
 			],
 			"description": "This docker image provides a Minecraft Server that will automatically download the latest stable version at startup. You can also run/upgrade to any specific version or the latest snapshot. See the Versions section below for more information.",
-            "image": "itzg/minecraft-server:multiarch-latest",
+            "image": "itzg/minecraft-server:latest",
                         "logo": "https://raw.githubusercontent.com/novaspirit/pi-hosted/master/images/minecraft.png",
                         "name": "minecraft",
                         "platform": "linux",

--- a/template/portainer-v2-arm32.json
+++ b/template/portainer-v2-arm32.json
@@ -2574,7 +2574,7 @@
                 "Games"
 			],
 			"description": "This docker image provides a Minecraft Server that will automatically download the latest stable version at startup. You can also run/upgrade to any specific version or the latest snapshot. See the Versions section below for more information.",
-            "image": "itzg/minecraft-server:multiarch-latest",
+            "image": "itzg/minecraft-server:latest",
                         "logo": "https://raw.githubusercontent.com/novaspirit/pi-hosted/master/images/minecraft.png",
                         "name": "minecraft",
                         "platform": "linux",

--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -2674,7 +2674,7 @@
                                 "Games"
                         ],
 						"description": "This docker image provides a Minecraft Server that will automatically download the latest stable version at startup. You can also run/upgrade to any specific version or the latest snapshot. See the Versions section below for more information.",
-                        "image": "itzg/minecraft-server:multiarch-latest",
+                        "image": "itzg/minecraft-server:latest",
                         "logo": "https://raw.githubusercontent.com/novaspirit/pi-hosted/master/images/minecraft.png",
                         "name": "minecraft",
                         "platform": "linux",


### PR DESCRIPTION
# Summary
Updated templates to use latest docker-minecraft-server image as multiarch-latest is deprecated **see [Deprecated Image Tags](https://github.com/itzg/docker-minecraft-server#deprecated-image-tags)** and the arm64 and arm32 images are included  in "latest".

# Why This Is Needed
The multiarch-latest no longer receives updates and was last updated a month ago **see [Docker Hub multiarch-latest tag Search](https://hub.docker.com/r/itzg/minecraft-server/tags?page=1&name=multiarch-latest) page.**

# What Changed
## Changed
- Updated templates to point to "latest" instead of "multiarch-latest" worked on testing with arm64 template.

# Checklist
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable? **Not necessary from what I saw**