### PR TITLE
fix for traefik container acme.json

### DIFF
--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -5149,7 +5149,7 @@
 				},
 				{
 					"bind": "/portainer/Files/AppData/Config/traefik/acme.json",
-					"container": "acme.json"
+					"container": "/acme.json"
 				},
 				{
 					"bind": "/var/run/docker.sock",


### PR DESCRIPTION
On installation it fails because missing "/"
