### PR TITLE
Add pre-commit hook file to build folder

### DIFF
--- a/build/env.sh
+++ b/build/env.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 
+# Portainer Templates
 pt32="${homedir}template/portainer-v2-arm32.json"
 pt64="${homedir}template/portainer-v2-arm64.json"
-AppList="${homedir}docs/TemplateList.md"
+
+# README Files with templates
 README="${homedir}docs/README.md"
 README_TEMPLATE="${homedir}build/README_Template.md"
 TOOLSREADME="${homedir}tools/README.md"
 TOOLSREADME_TEMPLATE="${homedir}build/tools_README_Template.md"
+
+# AppList Document
+AppList="${homedir}docs/TemplateList.md"
+
+# appinfo file
 appinfo="${homedir}build/appinfo.json"
+
+# Internal folders
 Scripts="${homedir}tools/"
 Extras="${homedir}tools/"
 Docs="${homedir}docs/"
+
+# Verification file
+verificationFile="${homedir}build/lastrun.sha256"

--- a/build/generateList.sh
+++ b/build/generateList.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# start script from it's folder
+cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null || exit
+
 # Standard file locations
 homedir='../'
 . env.sh

--- a/build/generateREADME.sh
+++ b/build/generateREADME.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# start script from it's folder
+cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null || exit
+
 # Standard file locations
 homedir='../'
 . env.sh

--- a/build/generateToolsREADME.sh
+++ b/build/generateToolsREADME.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# start script from it's folder
+cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null || exit
+
 # Standard file locations
 homedir='../'
 . env.sh

--- a/build/lastrun.sha256
+++ b/build/lastrun.sha256
@@ -1,0 +1,3 @@
+ef7231c2ed89eb25fcabe4c4ecb65969207525b7dadd3b557221bb8510f2d02a  ../build/appinfo.json
+600921725b754fca4589eb100398700c451f7f886fcd5578682f9e232aa16eb0  ../template/portainer-v2-arm32.json
+4ad926282eb9bd712948062dccb45c32c510f049d521b85f55561ee54fafb970  ../template/portainer-v2-arm64.json

--- a/build/pre-commit
+++ b/build/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Check if script from build or script from hook and cd into build folder
+scriptDir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null || pwd )"
+if [ "$( echo "$scriptDir" | rev | cut -d/ -f1 | rev )" == "build" ]; then
+	cd -- "$scriptDir" &> /dev/null || exit
+else
+	cd -- "$(git rev-parse --show-toplevel)/build" &> /dev/null || exit
+fi
+
+# Get file location (Variables) from env file
+homedir='../'
+. env.sh
+
+# Check if Template or appinfo has changed
+if ! sha256sum -c --quiet "$verificationFile" &> /dev/null ; then
+	echo "Updating documentation..."
+	# Run all scripts
+	./generateList.sh
+	./generateREADME.sh
+	./generateToolsREADME.sh
+	echo "Update finished"
+
+	# Update lastrun.sha256
+	sha256sum "$appinfo" "$pt32" "$pt64" > "$verificationFile" 
+
+	# Add files to stagging
+	git add -- "$verificationFile"
+	git add -- "$README"
+	git add -- "$TOOLSREADME"
+	git add -- "$AppList"
+fi

--- a/docs/TemplateList.md
+++ b/docs/TemplateList.md
@@ -76,7 +76,7 @@
 |Mylar|32/64 bit|Container|  |  |  |  |
 |n8n|32/64 bit|Container|  |  |  |  |
 |Netdata|32/64 bit|Container|  |  |  |  |
-|Nextcloud|32/64 bit|Stack|  |  | [reset_premissions_nextcloud.sh](../tools/reset_premissions_nextcloud.sh) |  |
+|Nextcloud|32/64 bit|Stack|  |  |  |  |
 |NextcloudPi|32/64 bit|Container|  |  | [reset_premissions_nextcloud.sh](../tools/reset_premissions_nextcloud.sh) | [![YouTube](https://img.shields.io/badge/YouTube-FF0000?style=plastic&logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=E6IrT3g5Gqc&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=9) |
 |Nginx|32/64 bit|Container|  |  |  |  |
 |Nginx Proxy Manager|32/64 bit|Stack| [![](../build/images/doc_icon.png)](../docs/nginx_proxy_manager.md) | [![](../build/images/script_icon.png)](../tools/nginx-proxy-manager.sh) |  | [![YouTube](https://img.shields.io/badge/YouTube-FF0000?style=plastic&logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=yl2Laxbqvo8&list=PL846hFPMqg3jwkxcScD1xw2bKXrJVvarc&index=10) |
@@ -117,6 +117,7 @@
 |Snippet-box|32/64 bit|Container|  |  |  |  |
 |Sonarr|32/64 bit|Container|  |  |  |  |
 |Speedtest Tracker|32/64 bit|Container|  |  |  |  |
+|Sshwifty|32/64 bit|Container|  |  |  |  |
 |SyncThing|32/64 bit|Container|  |  |  |  |
 |Tautulli|32/64 bit|Container|  |  |  |  |
 |TheLounge|32/64 bit|Container|  |  |  |  |


### PR DESCRIPTION
# Summary

pre-commit hook to update doc files if templates or appinfo file is modified.

# Why This Is Needed

Help maintain documentation up to date

## Added

- `build/pre-commit` -> hook that can be run from build folder or copied to `.git/hooks` to run automatically
- `build/lastrun.sha256` -> file to keep track if appinfo or templates have been modified since last run

## Changed

- `build/env.sh` -> got improved
- `docs/TemplateList.md` -> updated with last changes

## Fixed

Now `build/generate*` and `build/pre-commit` can be run from any folder.

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable?