### PR TITLE
Update jDownloader to use latest tag

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -1948,7 +1948,7 @@
 					"name": "MYJD_PASSWORD"
 				}
 			],
-			"image": "jaymoulin/jdownloader:1.4.3-armhf",
+			"image": "jaymoulin/jdownloader:latest",
 			"logo": "https://raw.githubusercontent.com/novaspirit/pi-hosted/master/images/jdownloader.png",
 			"name": "JDownloader",
 			"platform": "linux",

--- a/template/portainer-v2-arm32.json
+++ b/template/portainer-v2-arm32.json
@@ -1948,7 +1948,7 @@
 					"name": "MYJD_PASSWORD"
 				}
 			],
-			"image": "jaymoulin/jdownloader:1.4.3-armhf",
+			"image": "jaymoulin/jdownloader:latest",
 			"logo": "https://raw.githubusercontent.com/novaspirit/pi-hosted/master/images/jdownloader.png",
 			"name": "JDownloader",
 			"platform": "linux",

--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -2048,7 +2048,7 @@
 					"name": "MYJD_PASSWORD"
 				}
 			],
-			"image": "jaymoulin/jdownloader:1.4.3",
+			"image": "jaymoulin/jdownloader:latest",
 			"logo": "https://raw.githubusercontent.com/novaspirit/pi-hosted/master/images/jdownloader.png",
 			"name": "JDownloader",
 			"platform": "linux",


### PR DESCRIPTION
# Summary

Both templates are using a fixed version (1.4.3) that are a few months old now. The latest is 2.0.2. To avoid manually update, I've switched to `latest` tag.

It was tested and worked successfully on:

- Raspberry Pi 3 (32 bit)
- Raspberry Pi 4 (32 bit) (Tested by another user on Discord)
- Raspberry Pi 4 (64 bit)

# Why This Is Needed

Keep app up to date

# What Changed

All 3 templates

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated documentation, as applicable?