### PR TITLE
Remove lastrun.sha256 from git to avoid merging conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 
 .DS_Store
+
+# Ignore latest.run file from build hoook
+build/lastrun.sha256

--- a/build/lastrun.sha256
+++ b/build/lastrun.sha256
@@ -1,3 +1,0 @@
-ef7231c2ed89eb25fcabe4c4ecb65969207525b7dadd3b557221bb8510f2d02a  ../build/appinfo.json
-600921725b754fca4589eb100398700c451f7f886fcd5578682f9e232aa16eb0  ../template/portainer-v2-arm32.json
-4ad926282eb9bd712948062dccb45c32c510f049d521b85f55561ee54fafb970  ../template/portainer-v2-arm64.json

--- a/build/pre-commit
+++ b/build/pre-commit
@@ -25,7 +25,6 @@ if ! sha256sum -c --quiet "$verificationFile" &> /dev/null ; then
 	sha256sum "$appinfo" "$pt32" "$pt64" > "$verificationFile" 
 
 	# Add files to stagging
-	git add -- "$verificationFile"
 	git add -- "$README"
 	git add -- "$TOOLSREADME"
 	git add -- "$AppList"


### PR DESCRIPTION
# Summary

Remove `lastrun.sha256` file and add it to `.gitignore`

# Why This Is Needed

When I created `pre-commit` hook script, I used `lastrun.sha256` file to keep track if docs needs to be updated. However, I realize that doing so will create conflict between PR as multiple people will change the same file.

To avoid that, I've added that file to `.gitignore` and deleted it from GitHub.

The downside is that if you use the hook, it might run one extra trying to keep docs up to date, which I believe is better than dealing with merge conflicts.

# What Changed

<!-- A detailed list of all the changes made, broken down by category. -->

## Changed

Changed hook to not add sha256 to staging and `.gitignore`.

## Removed

Removed `lastrun.sha256` file

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated documentation, as applicable?