### PR TITLE
Fix Bookstack adding APP_URL env

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -317,6 +317,13 @@
 					"name": "MYSQL_ROOT_PASSWORD"
 				},
 				{
+					"default": "http://192.168.X.Y:6875",
+					"label": "APP_URL",
+					"name": "APP_URL",
+					"description": "Address to access Bookstrap. If using a domain, add it here. If not set correctly the app will not be accessible"
+				},
+				{
+					"default": "6875",
 					"label": "PORT",
 					"name": "PORT"
 				}

--- a/stack/bookstack.yml
+++ b/stack/bookstack.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - PUID=${PUID}
       - PGID=${PGID}
+      - APP_URL=${APP_URL}
       - DB_HOST=bookstack_db
       - DB_USER=bookstack
       - DB_PASS=${DATABASE_PASSWORD}

--- a/template/portainer-v2-arm32.json
+++ b/template/portainer-v2-arm32.json
@@ -317,6 +317,13 @@
 					"name": "MYSQL_ROOT_PASSWORD"
 				},
 				{
+					"default": "http://192.168.X.Y:6875",
+					"label": "APP_URL",
+					"name": "APP_URL",
+					"description": "Address to access Bookstrap. If using a domain, add it here. If not set correctly the app will not be accessible"
+				},
+				{
+					"default": "6875",
 					"label": "PORT",
 					"name": "PORT"
 				}

--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -317,6 +317,13 @@
 					"name": "MYSQL_ROOT_PASSWORD"
 				},
 				{
+					"default": "http://192.168.X.Y:6875",
+					"label": "APP_URL",
+					"name": "APP_URL",
+					"description": "Address to access Bookstrap. If using a domain, add it here. If not set correctly the app will not be accessible"
+				},
+				{
+					"default": "6875",
 					"label": "PORT",
 					"name": "PORT"
 				}


### PR DESCRIPTION
# Summary

Add `APP_URL` variable to fix Bookstack app.

# Why This Is Needed

Bookstack has an internal redirect command to it's base domain, which is set by `APP_URL` env. If this domain is not set, the app will default to your external IP.

Adding this variable allows user to define their own IP or domain name.

## Changed

Templates to add `APP_URL` env. I also set the a default value for PORT, making it easier for users that don't know which number to choose.

Bookstack Stack to use the new env variable.

## Fixed

Bookstrap can now run using any IP or domain name.

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated documentation, as applicable?