### PR TITLE
change freshrss image to fix error related to Apache

### DIFF
--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -1403,7 +1403,7 @@
 					"name": "PGID"
 				}
 			],
-			"image": "linuxserver/freshrss:latest",
+			"image": "freshrss/freshrss:arm",
 			"logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/freshrss-icon.png",
 			"name": "freshrss",
 			"platform": "linux",


### PR DESCRIPTION
for more error you can read this https://github.com/seazon/FeedMe/issues/67#issue-358096821

# Summary

<!-- A short summary describing what was done... -->
linuxserver build has lack of php5-gmp package and it make trouble when use other app like feedme. so replace that with original freshrss build for arm
## Fixed
https://github.com/seazon/FeedMe/issues/67#issue-358096821