### PR TITLE
Use same HomeAssistant name for 32 an 64bit template

### DIFF
--- a/template/portainer-v2-arm32.json
+++ b/template/portainer-v2-arm32.json
@@ -1720,13 +1720,13 @@
 			"description": "Home Assistant is a free and open-source software for home automation that is designed to be the central control system for smart home devices with focus on local control and privacy.",
 			"image": "homeassistant/home-assistant:latest",
 			"logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/homeassistant.png",
-			"name": "home assistant",
+			"name": "home-assistant",
 			"platform": "linux",
 			"ports": [
 				"8999:8123/tcp"
 			],
 			"restart_policy": "unless-stopped",
-			"title": "Homeassistant",
+			"title": "Home Assistant",
 			"type": 1,
 			"volumes": [
 				{


### PR DESCRIPTION
# Summary

Just aligning 32 and 64 bit names for Home Assistant.

# Why This Is Needed

This will allow the build functions for AppList to work properly.

# What Changed

32bit template to align with 64 bit

# Screenshots

<!-- Please include screenshots of any new features to show how it works. -->

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated documentation, as applicable?