### PR TITLE
change guacamole to arm64 image

### DIFF
--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -1718,8 +1718,8 @@
 				"Other",
 				"Tools"
 			],
-			"description": "[arm] A clientless remote desktop gateway.",
-			"image": "oznu/guacamole:armhf",
+			"description": "[arm64] A clientless remote desktop gateway.",
+			"image": "maxwaldorf/guacamole:latest",
 			"logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/guacamole.png",
 			"name": "guacamole",
 			"note": "The default login will be guacadmin/guacadmin. It is common practice to add a new admin user and remove the default user for Guacamole.",


### PR DESCRIPTION
## Changed
change the guacamole armhf image to arm64 image

from https://github.com/MaxWaldorf/guacamole based on oznu/guacamole image

link to docker hub: https://hub.docker.com/r/maxwaldorf/guacamole/tags?page=1

## Tested
tested with rpi 4 8gb