### PR TITLE
Adding volumes to FileBrowser to save the settings (arm64)

### DIFF
--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -1395,6 +1395,14 @@
 				{
 					"bind": "/portainer/Downloads",
 					"container": "/srv"
+				},
+				{
+					"bind": "/portainer/Files/AppData/Config/filebrowser/filebrowser.db",
+					"container": "/database/filebrowser.db"
+				},
+				{
+					"bind": "/portainer/Files/AppData/Config/filebrowser/settings.json",
+					"container": "/config/settings.json"
 				}
 			]
 		},


### PR DESCRIPTION
# Summary

Adding volumes to FileBrowser to save the settings, so it won't be lost when updating the container (e.g. losing user config and going back to admin/admin default login)

# Why This Is Needed

Without those volumes, all your setting will revert to default when the container is restarted or updated

# What Changed

Added volumes in the template file

# Screenshots

![image](https://user-images.githubusercontent.com/19187187/157017828-0a0c3cfb-537d-4859-bf36-b9e41bbc3c3b.png)

