### PR TITLE
Use latest instead of fixed version cadvisory

### DIFF
--- a/stack/raspberrypi-monitoring.yml
+++ b/stack/raspberrypi-monitoring.yml
@@ -7,7 +7,7 @@ services:
     expose:
       - 8080
     hostname: rpi-cadvisor
-    image: zcube/cadvisor:v0.37.5
+    image: zcube/cadvisor:latest
     ipc: shareable
     networks:
       - rpimonitor_default


### PR DESCRIPTION
<!-- The title of the pull request should be a short description of what was done.  -->

Use latest instead of fixed version cadvisory

# Why This Is Needed

Otherwise users will keep using the same version and never update, and generally it’s a good practice to update once in a while. The other images of this stack are also latest so it would me more sense.

ive also tested this in prod and I’m having no issues.