### PR TITLE
Fix jdownloader config path

### DIFF
--- a/template/apps/jdownloader.json
+++ b/template/apps/jdownloader.json
@@ -37,7 +37,7 @@
 	"volumes": [
 		{
 			"bind": "/portainer/Files/AppData/Config/JDownloader",
-			"container": "/opt/JDownloader/cfg"
+			"container": "/opt/JDownloader/app/cfg"
 		},
 		{
 			"bind": "/portainer/Downloads",


### PR DESCRIPTION
# Summary
Change to right config path, dont really know if this will fix, "no console available". Assuming the config not persistent before.
Reference https://github.com/jaymoulin/docker-jdownloader

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable?