### PR TITLE
Proposale to optimize cadvisory cpu usage

### DIFF
--- a/configs/prometheus.yml
+++ b/configs/prometheus.yml
@@ -1,5 +1,5 @@
 scrape_configs:
   - job_name: 'Pi-Hosted'
-    scrape_interval: 30s
+    scrape_interval: 45s
     static_configs:
       - targets: ['localhost:9090', 'cadvisor:8080', 'node-exporter:9100']

--- a/stack/raspberrypi-monitoring.yml
+++ b/stack/raspberrypi-monitoring.yml
@@ -4,6 +4,10 @@ services:
     command:
     - '--docker_only=true'
     - '--housekeeping_interval=30s'
+    - '--disable_metrics=accelerator,cpu_topology,disk,memory_numa,tcp,udp,percpu,sched,process,hugetlb,referenced_memory,resctrl,cpuset,advtcp,memory_numa'
+    - '--store_container_labels=false'
+    - '--event_storage_event_limit=default=0'
+    - '--event_storage_age_limit=default=0'
     container_name: monitoring-cadvisor
     devices:
       - /dev/kmsg:/dev/kmsg

--- a/stack/raspberrypi-monitoring.yml
+++ b/stack/raspberrypi-monitoring.yml
@@ -4,8 +4,6 @@ services:
     command:
     - '--docker_only=true'
     - '--housekeeping_interval=30s'
-    - '--disable_metrics=accelerator,cpu_topology,disk,memory_numa,tcp,udp,percpu,sched,process,hugetlb,referenced_memory,resctrl,cpuset,advtcp,memory_numa'
-    
     container_name: monitoring-cadvisor
     devices:
       - /dev/kmsg:/dev/kmsg

--- a/stack/raspberrypi-monitoring.yml
+++ b/stack/raspberrypi-monitoring.yml
@@ -1,6 +1,11 @@
 version: "2.4"
 services:
   cadvisor:
+    command:
+    - '--docker_only=true'
+    - '--housekeeping_interval=30s'
+    - '--disable_metrics=accelerator,cpu_topology,disk,memory_numa,tcp,udp,percpu,sched,process,hugetlb,referenced_memory,resctrl,cpuset,advtcp,memory_numa'
+    
     container_name: monitoring-cadvisor
     devices:
       - /dev/kmsg:/dev/kmsg


### PR DESCRIPTION
A WIP of arguments to add to make the container cadvisory use way less cpu.

<!-- The title of the pull request should be a short description of what was done.  -->
I've been experimenting with arguments on cadvisory as it was using the most cpu by alot compared to my other containers.
Used sources:
https://github.com/google/cadvisor/blob/master/docs/runtime_options.md
https://github.com/google/cadvisor/issues/2523
the arguments are taken from the help page of cadvisory when ran in a terminal. And tweaked based on this dashboard:
https://grafana.com/grafana/dashboards/15120

I've added 2 arguments which do the following:

'--docker_only=true' 
Quoting the help: "Only report docker containers in addition to root stats". As i believe cadvisory is used mostly for containers, enabeling this disabled already a few metrics which lowered cpu usage alot.

'--housekeeping_interval=29s'
See: https://github.com/google/cadvisor/blob/master/docs/runtime_options.md#housekeeping-intervals
Per-container housekeeping is run once on each container cAdvisor tracks. This typically gets container stats.
B/c the smallest size of updates is every half a minute, i would suggest doing a 29 second interval.
I might be wrong, but i would say this checks the stats of the container, and based on that reports to grafana. So the higher the number the less accurate the stats, but the higher the more cpu usage it costs?

# Why This Is Needed

This could save alot of cpu cycles for new users and also show outliers easier in grafana.

# What Changed

Added 2 arguments (CMD) to the compose file for the rpi-monitor stack.

# Notes
This PR is still in wip as i do want to double check this with someone else. Currently my own dashboard that i mixed from multiple dashboards is running fine, but the rpi-monitor doesn't weirdly enough. Even withoud any CMD args it still shows dots instead of a continous line on some graphs like the r/w for containers.

This is what i tested with the arguments:
Given a rpi 4b the usage of the container cadvisory was 11-12%.
This got reduced to 4-7% with using docker-only.
And by adding the housekeeping_interval to 30 seconds. This reduced it to as low as 1.19-3.45%.