### PR TITLE
Image correction

### DIFF
--- a/template/apps/rutorrent.json
+++ b/template/apps/rutorrent.json
@@ -60,8 +60,8 @@
 			"name": "RU_REMOVE_CORE_PLUGINS"
 		}
 	],
-	"image32": "linuxserver/crazymax/rtorrent-rutorrent:latest",
-	"image64": "linuxserver/crazymax/rtorrent-rutorrent:latest",
+	"image32": "crazymax/rtorrent-rutorrent:latest",
+	"image64": "crazymax/rtorrent-rutorrent:latest",
 	"logo": "https://raw.githubusercontent.com/linuxserver/beta-templates/master/lsiodev/img/rutorrent-icon.png",
 	"name": "rutorrent",
 	"note": "For ruTorrent basic auth, XMLRPC through nginx and WebDAV on completed downloads, you can populate .htpasswd files with the following command:\ndocker run --rm -it httpd:2.4-alpine htpasswd -Bbn <username> <password> >> $(pwd)/passwd/webdav.htpasswd",


### PR DESCRIPTION
image32 and image64 values had invalid links to hub.docker

# Warning we automaticly generate the following files
# docs/README.md, template/portainer-v2-arm32.json, template/portainer-v2-arm64.json, tools/README.md, docs/AppList.md, docs/DocumentList.md, pi-hosted_template/template/portainer-v2.json 
# Please make any changes to these files instead 
# template/apps/*, build/templates/* build/info.json

<!-- The title of the pull request should be a short description of what was done.  -->

<!-- You can remove any parts of this template not applicable to your Pull Request.  -->

# Summary

<!-- A short summary describing what was done... -->

# Previous json file had invalid links to docker.hub

<!-- Explain why this change is needed. Can be omitted if covered in the summary. -->

# Without this change the deployment cannot be executed

<!-- Did any functionality change? -->

## No

<!-- Were any bugs fixed? -->

## Yes 

<!-- Was anything removed? -->

# No

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [Y] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [Y] Does your submission pass tests?
- [Y] Have you linted your code locally prior to submission?
- [Y] Have you added an explanation of what your changes do and why you'd like us to include them?
- [N] Have you updated documentation, as applicable?
