### PR TITLE
Fix missing comma on qflood json

### DIFF
--- a/template/apps/qflood.json
+++ b/template/apps/qflood.json
@@ -34,7 +34,7 @@
 	"image64": "hotio/qflood:latest",
 	"logo": "https://raw.githubusercontent.com/jesec/flood/master/flood.svg",
 	"name": "qflood",
-	"note": "The default qBittorrent username is admin and the default password is adminadmin."
+	"note": "The default qBittorrent username is admin and the default password is adminadmin.",
 	"officialDoc": "https://hotio.dev/containers/qflood/",
 	"platform": "linux",
 	"ports": [


### PR DESCRIPTION
# Summary

Bug fix on `qflood.json`, missing comma.

# Why This Is Needed

Remove bug when generating template

## Changed

only qflood app file

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated documentation, as applicable?
