### PR TITLE
Add cleanup option to Watchtower

### DIFF
--- a/template/apps/watchtower.json
+++ b/template/apps/watchtower.json
@@ -5,6 +5,23 @@
 		"Maintenance"
 	],
 	"description": "With watchtower you can update the running version of your containerized app simply by pushing a new image to the Docker Hub or your own image registry. Watchtower will pull down your new image, gracefully shut down your existing container and restart it with the same options that were used when it was deployed initially.",
+	"env": [
+		{
+			"label": "WATCHTOWER_CLEANUP",
+			"name": "WATCHTOWER_CLEANUP",
+			"select": [
+				{
+					"default": true,
+					"text": "Delete unused images",
+					"value": "true"
+				},
+				{
+					"text": "Keep unused images",
+					"value": "false"
+				}
+			]
+		}
+	],
 	"image32": "containrrr/watchtower:latest",
 	"image64": "containrrr/watchtower:latest",
 	"logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/watchtower.png",


### PR DESCRIPTION
# Summary

Add env variable to **Watchtower** cleanup unused images (#329)

# Why This Is Needed

Improve usability and give more options to users

# What Changed

`WATCHTOWER_CLEANUP` variable added with dropdown options.

# Checklist

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated documentation, as applicable?
