### PR TITLE
Update graylog.json

### DIFF
--- a/template/apps/graylog.json
+++ b/template/apps/graylog.json
@@ -26,7 +26,7 @@
 	"repository": {
 		"stackfile_arm64": "stack/graylog.yml",
 		"stackfile_amd64": "stack/graylog.yml",
-		"url": "https://github.com/Griffen8280/pi-hosted"
+		"url": "https://github.com/novaspirit/pi-hosted"
 	},
 	"restart_policy": "unless-stopped",
 	"title": "Graylog",

--- a/template/apps/graylog.json
+++ b/template/apps/graylog.json
@@ -26,7 +26,7 @@
 	"repository": {
 		"stackfile_arm64": "stack/graylog.yml",
 		"stackfile_amd64": "stack/graylog.yml",
-		"url": "https://github.com/novaspirit/pi-hosted"
+		"url": "https://github.com/pi-hosted/pi-hosted"
 	},
 	"restart_policy": "unless-stopped",
 	"title": "Graylog",


### PR DESCRIPTION
reverting the URL back to novaspirit/pi-hosted instead of my fork.

## Warning we automatically generate the following files, your change(s) will overwritten.
* docs/README.md
* template/portainer-v2-arm32.json
* template/portainer-v2-arm64.json
* template/portainer-v2-amd64.json
* tools/README.md
* docs/AppList.md
* docs/DocumentList.md
* pi-hosted_template/template/portainer-v2.json 

## Please make any changes to these files instead 
* template/apps/`some-application-name.json`
* stack/`some-stack-name.yml` 
* docs/`some-docsname.md`
* tools/`some-script.sh`
* build/info.json

<!-- Fill with - if not applicable-->
## Summary
Template URL was pointing to the wrong repo.

### Why This Is Needed
Keep everything in one place

### What Changed
https://github.com/Griffen8280/pi-hosted/ -> https://github.com/novaspirit/pi-hosted/

### Added
<!-- What was added? -->

### Changed
<!-- Did any functionality change? -->

### Fixed
<!-- Were any bugs fixed? -->

### Removed
<!-- Was anything removed? -->

### Screenshots
<!-- Please include screenshots of any new features to show how it works. -->

## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [ X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ X] Does your submission pass tests?
- [ X] Have you linted your code locally prior to submission?
- [ X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ X] Have you updated documentation, as applicable?1
