### PR TITLE
workflow: use github actions official email/username

### DIFF
--- a/.github/workflows/automategeneration.yml
+++ b/.github/workflows/automategeneration.yml
@@ -51,8 +51,8 @@ jobs:
       run: build/generators/generateToolsREADME.sh
     - name: Commit files
       run: |
-        git config --local user.email "workflow@github.com"
-        git config --local user.name "GitHub Workflow"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
         git add -- "$ptArm32"
         git add -- "$ptArm64"
         git add -- "$ptAmd64"


### PR DESCRIPTION
Changes the commit profile from: 
![image](https://user-images.githubusercontent.com/71036629/193432674-155e5d8b-3e5e-418c-967a-ce82083ba353.png)

to:
![image](https://user-images.githubusercontent.com/71036629/193432702-92a40ce8-4a0a-4569-ae36-7b774b88f981.png)

Just a simple cosmetic change, but it never hurts :)