### PR TITLE
Volume bind fix

### DIFF
--- a/template/apps/Firefox.json
+++ b/template/apps/Firefox.json
@@ -30,7 +30,7 @@
 	"volumes": [
 		{
 			"bind": "/portainer/Files/AppData/Config/firefox",
-			"container": "/app/public/conf.yml"
+			"container": "/config"
 		}
 	],
 	"webpage": "https://hub.docker.com/r/linuxserver/firefox"

--- a/template/apps/QuakeJs.json
+++ b/template/apps/QuakeJs.json
@@ -30,11 +30,5 @@
 	"restart_policy": "unless-stopped",
 	"title": "QuakeJs",
 	"type": 1,
-	"volumes": [
-		{
-			"bind": "/portainer/Files/AppData/Config/QuakeJs",
-			"container": "/app/public/conf.yml"
-		}
-	],
 	"webpage": "https://registry.hub.docker.com/r/chrisscottthomas/quakejs/"
 }

--- a/template/apps/filezilla.json
+++ b/template/apps/filezilla.json
@@ -38,7 +38,7 @@
 	"volumes": [
 		{
 			"bind": "/portainer/Files/AppData/Config/filezilla",
-			"container": "/app/public/conf.yml"
+			"container": "/config"
 		}
 
 	],

--- a/template/apps/pwndrop.json
+++ b/template/apps/pwndrop.json
@@ -42,7 +42,7 @@
 	"volumes": [
 		{
 			"bind": "/portainer/Files/AppData/Config/pwndrop",
-			"container": "/app/public/conf.yml"
+			"container": "/config"
 		}
 
 	],


### PR DESCRIPTION
## Warning we automatically generate the following files, your change(s) will overwritten.
* docs/README.md
* template/portainer-v2-arm32.json
* template/portainer-v2-arm64.json
* template/portainer-v2-amd64.json
* tools/README.md
* docs/AppList.md
* docs/DocumentList.md
* pi-hosted_template/template/portainer-v2.json 

## Please make any changes to these files instead 
* template/apps/`some-application-name.json`
* stack/`some-stack-name.yml` 
* docs/`some-docsname.md`
* tools/`some-script.sh`
* build/info.json

<!-- Fill with - if not applicable-->
## Summary
Fixing binding path

### Why This Is Needed
Last few PR quakejs firefox FileZilla pwndrop volume bind to `/app/public/conf.yml`

### What Changed
* Firefox config bind
* Pwndrop config bind
* Filezilla config bind
* Remove Quakejs volume, lack of upstream docs.

### Added
* --

### Changed
* --

### Fixed
* --

### Removed
* --

### Screenshots
<!-- Please include screenshots of any new features to show how it works. -->
* --

## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable?1
