### PR TITLE
Fix container policy attribute typo.

### DIFF
--- a/template/apps/foundryvtt-server.json
+++ b/template/apps/foundryvtt-server.json
@@ -36,7 +36,7 @@
 	"ports": [
 		"30000:30000/tcp"
 	],
-	"restart_polocy": "unless-stopped",
+	"restart_policy": "unless-stopped",
 	"title": "FoundryVTT Server",
 	"type": 1,
 	"volumes": [

--- a/template/apps/minecraft-server.json
+++ b/template/apps/minecraft-server.json
@@ -22,7 +22,7 @@
 	"ports": [
 		"25565:25565/tcp"
 	],
-	"restart_polocy": "unless-stopped",
+	"restart_policy": "unless-stopped",
 	"title": "Minecraft Server",
 	"type": 1,
 	"volumes": [


### PR DESCRIPTION
## Warning we automatically generate the following files, your change(s) will overwritten.
* docs/README.md
* template/portainer-v2-arm32.json
* template/portainer-v2-arm64.json
* template/portainer-v2-amd64.json
* tools/README.md
* docs/AppList.md
* docs/DocumentList.md
* pi-hosted_template/template/portainer-v2.json 

## Please make any changes to these files instead 
* template/apps/`some-application-name.json`
* stack/`some-stack-name.yml` 
* docs/`some-docsname.md`
* tools/`some-script.sh`
* build/info.json

<!-- Fill with - if not applicable-->
## Summary
Fixed the typo of the word "policy" in the container policy from "restart_polocy" to "restart_policy."

### Why This Is Needed
The attribute name is otherwise incorrect and will further be generated incorrectly into the JSON template files.

### What Changed
Fixed the misspelling of "polocy" to "policy" for the two app templates in the commit.

### Added
-

### Changed
-

### Fixed
-

### Removed
-

### Screenshots
-

## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
