### PR TITLE
Update homebridge app templates to use new/current homebridge docker hub repo

### DIFF
--- a/template/apps/homebridge-debian.json
+++ b/template/apps/homebridge-debian.json
@@ -30,9 +30,9 @@
 			"name": "TZ"
 		}
 	],
-	"image_arm32": "oznu/homebridge:debian-arm32v7",
-	"image_arm64": "oznu/homebridge:debian",
-	"image_amd64": "oznu/homebridge:debian",
+	"image_arm32": "homebridge/homebridge:ubuntu-arm32v7",
+	"image_arm64": "homebridge/homebridge:ubuntu",
+	"image_amd64": "homebridge/homebridge:ubuntu",
 	"logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/homebridge.png",
 	"name": "homebridge-debian",
 	"network": "host",

--- a/template/apps/homebridge.json
+++ b/template/apps/homebridge.json
@@ -30,9 +30,9 @@
 			"name": "TZ"
 		}
 	],
-	"image_arm32": "oznu/homebridge:latest",
-	"image_arm64": "oznu/homebridge:latest",
-	"image_amd64": "oznu/homebridge:latest",
+	"image_arm32": "homebridge/homebridge:latest",
+	"image_arm64": "homebridge/homebridge:latest",
+	"image_amd64": "homebridge/homebridge:latest",
 	"logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/homebridge.png",
 	"name": "homebridge",
 	"network": "host",


### PR DESCRIPTION
Relevant links:

https://hub.docker.com/r/homebridge/homebridge/tags
https://github.com/homebridge/docker-homebridge/wiki/Homebridge-on-Raspberry-Pi/_history
https://github.com/homebridge/docker-homebridge/wiki/Homebridge-on-Raspberry-Pi#3-create-docker-compose-manifest

<img width="1022" alt="Screenshot 2023-08-05 at 8 18 35 PM" src="https://github.com/novaspirit/pi-hosted/assets/1268088/6e6f126c-8509-4c94-b247-ba71eacf9364">
<img width="1426" alt="Screenshot 2023-08-05 at 8 18 27 PM" src="https://github.com/novaspirit/pi-hosted/assets/1268088/ccf6043a-bbf5-4c4a-bcc8-6eaf8698a871">

