### PR TITLE
Fix issue 166 invliad mapping from /app/data to /data

### DIFF
--- a/template/apps/flatnotes.json
+++ b/template/apps/flatnotes.json
@@ -42,7 +42,7 @@
         "volumes": [
                 {
                         "bind": "/portainer/Files/AppData/Config/flatnotes/data",
-                        "container": "/app/data"
+                        "container": "/data"
                 }
 	],
 	"webpage": "https://github.com/Dullage/flatnotes"

--- a/template/portainer-v2-amd64.json
+++ b/template/portainer-v2-amd64.json
@@ -2246,7 +2246,7 @@
 			"volumes": [
 				{
 					"bind": "/portainer/Files/AppData/Config/flatnotes/data",
-					"container": "/app/data"
+					"container": "/data"
 				}
 			],
 			"note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/Dullage/flatnotes\" target=\"_blank\">https://github.com/Dullage/flatnotes</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/dullage/flatnotes\" target=\"_blank\">https://hub.docker.com/r/dullage/flatnotes</a><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/install_flatnotes.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/install_flatnotes.sh | bash</h3><br><br>"

--- a/template/portainer-v2-arm64.json
+++ b/template/portainer-v2-arm64.json
@@ -2204,7 +2204,7 @@
 			"volumes": [
 				{
 					"bind": "/portainer/Files/AppData/Config/flatnotes/data",
-					"container": "/app/data"
+					"container": "/data"
 				}
 			],
 			"note": "<b>Template created by Pi-Hosted Series</b><br><b>Check our Github page: <a href=\"https://github.com/pi-hosted/pi-hosted\" target=\"_blank\">https://github.com/pi-hosted/pi-hosted</a></b><br><br><b>Official Webpage: </b><a href=\"https://github.com/Dullage/flatnotes\" target=\"_blank\">https://github.com/Dullage/flatnotes</a><br><b>Official Docker Documentation: </b><a href=\"https://hub.docker.com/r/dullage/flatnotes\" target=\"_blank\">https://hub.docker.com/r/dullage/flatnotes</a><br><br><h3><b><a href=\"https://github.com/pi-hosted/pi-hosted/blob/master/tools/install_flatnotes.sh\" target=\"_blank\">Pre-installation script</a> must be RAN before you install: </b>wget -qO- https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/tools/install_flatnotes.sh | bash</h3><br><br>"


### PR DESCRIPTION
<!-- Fill with - if not applicable-->
## Summary
<!-- A short summary describing what was done... -->
Upon investigation, it appears that there is a typo in the container path "/app/data." This typo results in an invalid volume mapping, which fails to save Flatnotes data to the target path of "/portainer/Files/AppData/Config/flatnotes/data."

As a consequence of this issue, unnecessary docker GUID volumes are being created when the container is initiated. This leads to unnecessary clutter and inefficiency.

### Why This Is Needed
<!-- Explain why this change is needed. Can be omitted if covered in the summary. -->
After conducting tests, I have confirmed that the application expects the path "/data." When this path is correctly configured, the data saves as expected to the targeted path ("/portainer/Files/AppData/Config/flatnotes/data") without the creation of unnecessary docker volumes.

### What Changed
<!-- A detailed list of all the changes made, broken down by category. -->
Typo in the container path "/app/data" to "/data"
template/apps/flatnotes.json
template/portainer-v2-amd64.json
template/portainer-v2-arm64.json

### Added
<!-- What was added? -->
NA

### Changed
<!-- Did any functionality change? -->
NA

### Fixed
<!-- Were any bugs fixed? -->
Yes - #466 

### Removed
<!-- Was anything removed? -->
NA

### Screenshots
<!-- Please include screenshots of any new features to show how it works. -->
NA

## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated documentation, as applicable?