### PR TITLE
Lock up reactive resume version

### DIFF
--- a/stack/reactive-resume.yml
+++ b/stack/reactive-resume.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   app:
-    image: martadinata666/reactive-resume:latest
+    image: martadinata666/reactive-resume:v3.8.4
     restart: unless-stopped
     environment:
       - SECRET_KEY=${SECRET_KEY}
@@ -16,8 +16,8 @@ services:
       - PUBLIC_URL=${PUBLIC_URL}
       - PUBLIC_SERVER_URL=${PUBLIC_SERVER_URL}
     volumes:
-      - /portainer/Files/AppData/Config/reactive-resume/uploads:/home/debian/reactiveresume/server/dist/assets/uploads
-      - /portainer/Files/AppData/Config/reactive-resume/exports:/home/debian/reactiveresume/server/dist/assets/exports
+      - /portainer/Files/AppData/Config/reactive-resume/uploads:/home/docker/reactiveresume/server/dist/assets/uploads
+      - /portainer/Files/AppData/Config/reactive-resume/exports:/home/docker/reactiveresume/server/dist/assets/exports
     ports:
       - ${CLIENT_PORT}:3000
       - ${SERVER_PORT}:3100

--- a/template/apps/reactive-resume.json
+++ b/template/apps/reactive-resume.json
@@ -4,10 +4,10 @@
 		"Tools"
 	],
 	"description": "A one-of-a-kind resume builder that's not out to get your data. Completely secure, customizable, portable, open-source and free forever.",
-	"image_arm64": "martadinata666/reactive-resume:latest",
-	"image_amd64": "martadinata666/reactive-resume:latest",
+	"image_arm64": "martadinata666/reactive-resume:v3.8.4",
+	"image_amd64": "martadinata666/reactive-resume:v3.8.4",
 	"logo": "https://raw.githubusercontent.com/pi-hosted/pi-hosted/master/images/reactiveresume.png",
-	"name": "reactive-resume",
+	"name": "reactive-resume v3",
 	"officialDoc": "https://hub.docker.com/r/martadinata666/reactive-resume",
 	"preInstallScript": "install_reactive-resume.sh",
 	"platform": "linux",


### PR DESCRIPTION
## Warning we automatically generate the following files, your change(s) will overwritten.
* docs/README.md
* template/portainer-v2-arm32.json
* template/portainer-v2-arm64.json
* template/portainer-v2-amd64.json
* tools/README.md
* docs/AppList.md
* docs/DocumentList.md
* pi-hosted_template/template/portainer-v2.json 

## Please make any changes to these files instead 
* template/apps/`some-application-name.json`
* stack/`some-stack-name.yml` 
* docs/`some-docsname.md`
* tools/`some-script.sh`
* build/info.json

<!-- Fill with - if not applicable-->
## Summary
Lock reactive resume version to v3.8.4

### Why This Is Needed
Reactive resume v4 released, but a whole different setup.

### What Changed
Tag lock
Correct uploads and assets path

### Fixed
Incorrect assets &  exports path

### Removed
<!-- Was anything removed? -->


## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable?1
