### PR TITLE
Fixed naming issue in alexa-wake-on-lan.json

### DIFF
--- a/template/apps/alexa-wake-on-lan.json
+++ b/template/apps/alexa-wake-on-lan.json
@@ -8,7 +8,7 @@
 	"image_arm64": "cristianeduardmihai/alexa-wol:latest",
 	"image_amd64": "cristianeduardmihai/alexa-wol:latest",
 	"logo": "https://raw.githubusercontent.com/CristianEduardMihai/alexa-wol/main/images/logo.jpg",
-	"name": "Alexa Wake On Lan",
+	"name": "Alexa-Wake-On-Lan",
 	"officialDoc": "https://github.com/CristianEduardMihai/alexa-wol",
 	"platform": "linux",
 	"network": "host",


### PR DESCRIPTION
<!-- Fill with - if not applicable-->
## Summary
Removed spaces from `Alexa wake on lan` container name

### Why This Is Needed
Docker doesn't allow spaces in the container names

### What Changed
Changed `"name": "Alexa Wake On Lan",` to `"name": "Alexa-Wake-On-Lan",` in `template/apps/alexa-wake-on-lan.json`

### Added
-

### Changed
-

### Fixed
- This issue:
![Screenshot 2023-12-09 004220](https://github.com/novaspirit/pi-hosted/assets/59600013/aabf5fd7-10f3-4ce7-b542-c7260e536c3f)

### Removed
-

### Screenshots
-

## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you linted your code locally prior to submission?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you updated documentation, as applicable?1
