### PR TITLE
Added hmac_key parameter in invidious stack

### DIFF
--- a/stack/invidious-amd64.yml
+++ b/stack/invidious-amd64.yml
@@ -27,6 +27,7 @@ services:
         registration_enabled: ${REGISTRATION_ENABLED}
         login_enabled: ${LOGIN_ENABLED}
         captcha_enabled: ${CAPTCHA_ENABLED}
+        hmac_key: ${HMAC_KEY}
         channel_threads: 1
         feed_threads: 1
         default_user_preferences:

--- a/template/apps/invidious.json
+++ b/template/apps/invidious.json
@@ -134,6 +134,11 @@
 			]
 		},
 		{
+			"default": "CHANGE_ME!!!",
+			"label": "HMAC_KEY",
+			"name": "HMAC_KEY"
+		},
+		{
 			"default": "US",
 			"description": "Look in the configuration example (link above) for more codes",
 			"label": "REGION",

--- a/tools/install_invidious.sh
+++ b/tools/install_invidious.sh
@@ -41,3 +41,4 @@ sudo chmod +x "${BASE_DIR}/$f"
 
 echo "Preparation completed, proceed installation in portainer"
 echo -e "Suggestion for \\e[1mDB_PASSWORD\\e[39m: \\e[33m$(openssl rand -base64 24)\\e[39m"
+echo -e "Suggestion for \\e[1mHMAC_KEY\\e[39m: \\e[33m$(openssl rand -hex 20)\\e[39m"


### PR DESCRIPTION
As of july 1st, an hmac_key is mandatory for invidious to start


## Please make any changes to these files instead 
* template/apps/`invidious.json`
* stack/`invidious-amd64.yml` 
* tools/`install_invidious.sh`

## Summary
As of july 1st, an hmac_key is mandatory for invidious to start,

### Why This Is Needed
Without the hmac_key, the program WILL NOT run. It is a required parameter

### What Changed
Added a hmac_key parameter in the above files as well an extra line in the script to generate a sample hmac_key

### Added
* Addedd a hmac_key in the docker-compose file (stack/invidious-amd64.yml)
* Added hmac_key as a variable (template/apps/invidious.json)
* Added a line in the script to generate a hmac_key (tools/install_invidious.sh)

### Changed
No, nothing was changed

### Fixed
Yes, without this, the user needed to edit the docker compose file manually and add the hmac_key in the config

### Removed
No, nothing was removed

