### PR TITLE
use latest mysql for wordpress stack

### DIFF
--- a/stack/wordpress-stack.yml
+++ b/stack/wordpress-stack.yml
@@ -1,7 +1,6 @@
-version: '3.1'
+version: "3.1"
 
 services:
-
   wordpress:
     image: wordpress
     container_name: wordpress
@@ -14,12 +13,12 @@ services:
       WORDPRESS_DB_PASSWORD: ${MYSQL_DATABASE_PASSWORD}
       WORDPRESS_DB_NAME: wordpress
     networks:
-      - wordpress     
+      - wordpress
     volumes:
       - wordpress:/var/www/html
 
   db:
-    image: jc21/mariadb-aria:latest
+    image: mysql:8.0
     restart: unless-stopped
     environment:
       MYSQL_DATABASE: wordpress
@@ -27,7 +26,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_DATABASE_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_DATABASE_ROOT_PASSWORD}
     networks:
-      - wordpress     
+      - wordpress
     volumes:
       - db:/var/lib/mysql
 


### PR DESCRIPTION
## Summary
currently, the wordpress stack deploys a mysql 6.x that's 2 major versions behind.

### Why This Is Needed
this may lead to security vulnerabilities

### What Changed
wordpress stack db iamge


## Checklist
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Does your submission pass tests?
- [ ] Have you linted your code locally prior to submission?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you updated documentation, as applicable?1
